### PR TITLE
chore: Upgrade Swashbuckle.AspNetCore packages to version 10.0.0 acro…

### DIFF
--- a/Sample/Senparc.CO2NET.Sample.net6/Senparc.CO2NET.Sample.net6.csproj
+++ b/Sample/Senparc.CO2NET.Sample.net6/Senparc.CO2NET.Sample.net6.csproj
@@ -27,9 +27,9 @@
 		<ProjectReference Include="..\..\src\Senparc.CO2NET.WebApi\Senparc.CO2NET.WebApi.csproj" />
 		<ProjectReference Include="..\..\src\Senparc.CO2NET\Senparc.CO2NET.csproj" />
 
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/Sample/Senparc.CO2NET.Sample.net7/Senparc.CO2NET.Sample.net7.csproj
+++ b/Sample/Senparc.CO2NET.Sample.net7/Senparc.CO2NET.Sample.net7.csproj
@@ -27,9 +27,9 @@
 		<ProjectReference Include="..\..\src\Senparc.CO2NET.WebApi\Senparc.CO2NET.WebApi.csproj" />
 		<ProjectReference Include="..\..\src\Senparc.CO2NET\Senparc.CO2NET.csproj" />
 
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/Sample/Senparc.CO2NET.Sample.net8/Senparc.CO2NET.Sample.net8.csproj
+++ b/Sample/Senparc.CO2NET.Sample.net8/Senparc.CO2NET.Sample.net8.csproj
@@ -24,9 +24,9 @@
 		<ProjectReference Include="..\..\src\Senparc.CO2NET.WebApi\Senparc.CO2NET.WebApi.csproj" />
 		<ProjectReference Include="..\..\src\Senparc.CO2NET\Senparc.CO2NET.csproj" />
 
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/Senparc.CO2NET.WebApi/Senparc.CO2NET.WebApi.csproj
+++ b/src/Senparc.CO2NET.WebApi/Senparc.CO2NET.WebApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
-    <Version>2.1.4</Version>
+    <Version>2.1.5</Version>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Senparc.CO2NET.WebApi</AssemblyName>
     <RootNamespace>Senparc.CO2NET.WebApi</RootNamespace>
@@ -51,6 +51,7 @@
 			[2025-08-20] v2.1.2 feat: Add default value GET to DefaultRequestMethod proprety
 			[2025-08-20] v2.1.2.1 Update async detection logic in DocMethodInfo and increment project version
 			[2025-09-06] v2.1.3 base module update
+			[2025-11-21] v2.1.5 feat: update Swashbuckle.AspNetCore to v10.0.0
 </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -70,7 +71,7 @@
     <None Include="..\Senparc.CO2NET\icon.jpg" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.0" />
     <!--<PackageReference Include="System.Reflection.Emit" Version="4.7.0" />-->
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">

--- a/src/Senparc.CO2NET.WebApi/Senparc.CO2NET.WebApi.csproj
+++ b/src/Senparc.CO2NET.WebApi/Senparc.CO2NET.WebApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
-    <Version>2.1.5</Version>
+    <Version>2.1.6-preview.1</Version>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Senparc.CO2NET.WebApi</AssemblyName>
     <RootNamespace>Senparc.CO2NET.WebApi</RootNamespace>
@@ -51,7 +51,7 @@
 			[2025-08-20] v2.1.2 feat: Add default value GET to DefaultRequestMethod proprety
 			[2025-08-20] v2.1.2.1 Update async detection logic in DocMethodInfo and increment project version
 			[2025-09-06] v2.1.3 base module update
-			[2025-11-21] v2.1.5 feat: update Swashbuckle.AspNetCore to v10.0.0
+			[2025-11-21] v2.1.5 feat: update Swashbuckle.AspNetCore.Annotations to v10.0.0 for .NET 8.0 (netstandard2.1 remains on v6.5.0 for compatibility)
 </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -70,10 +70,13 @@
   <ItemGroup>
     <None Include="..\Senparc.CO2NET\icon.jpg" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.0" />
-    <!--<PackageReference Include="System.Reflection.Emit" Version="4.7.0" />-->
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
+  </ItemGroup>
+  <!--<PackageReference Include="System.Reflection.Emit" Version="4.7.0" />-->
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />


### PR DESCRIPTION
…ss multiple project files

Updated the Swashbuckle.AspNetCore, Swashbuckle.AspNetCore.Annotations, and Swashbuckle.AspNetCore.SwaggerGen package references to version 10.0.0 in the .csproj files for net6, net7, and net8 projects. Additionally, incremented the version number of Senparc.CO2NET.WebApi from 2.1.4 to 2.1.5 to reflect these changes.